### PR TITLE
feat(team): Hide CaseManagerInfo if no managed neutrals

### DIFF
--- a/src/app/(with-color-blur)/team/[member]/page.tsx
+++ b/src/app/(with-color-blur)/team/[member]/page.tsx
@@ -273,40 +273,32 @@ function Availability({ dateStr }: { dateStr: string }) {
 
 function CaseManagerInfo({ member }: { member: MemberInfoCaseManagerFragment }) {
   const { neutrals } = member;
-  return (
+  return neutrals.length > 0 ? (
     <div className="stack-y-3">
       <h3 className={heading({ type: '6' })}>Managed Neutrals</h3>
       <ul className="stack-y-1">
-        {neutrals.length > 0 ? (
-          <>
-            {neutrals.map((neutral) => {
-              const { memberPage } = neutral;
-              const { slug } = memberPage ?? {};
-              const { name } = neutral.info;
+        {neutrals.map((neutral) => {
+          const { memberPage } = neutral;
+          const { slug } = memberPage ?? {};
+          const { name } = neutral.info;
 
-              return (
-                <ListItem key={neutral.id} className="linkBox relative flex justify-between">
-                  <p>{name}</p>
+          return (
+            <ListItem key={neutral.id} className="linkBox relative flex justify-between">
+              <p>{name}</p>
 
-                  <CircleButton
-                    aria-label={`Visit ${name}'s page`}
-                    className="linkOverlay"
-                    href={`${PATHS.team}/${slug ?? ''}`}
-                  >
-                    <IconArrowTopRight aria-hidden />
-                  </CircleButton>
-                </ListItem>
-              );
-            })}
-          </>
-        ) : (
-          <ListItem className="relative flex justify-between">
-            <p className="text-base font-normal">No managed neutrals at this time.</p>
-          </ListItem>
-        )}
+              <CircleButton
+                aria-label={`Visit ${name}'s page`}
+                className="linkOverlay"
+                href={`${PATHS.team}/${slug ?? ''}`}
+              >
+                <IconArrowTopRight aria-hidden />
+              </CircleButton>
+            </ListItem>
+          );
+        })}
       </ul>
     </div>
-  );
+  ) : null;
 }
 
 interface ListItemProps {


### PR DESCRIPTION
- Conditionally render the CaseManagerInfo component only if the member has managed neutrals.
- This prevents the display of an empty "Managed Neutrals" section when there are no neutrals assigned to the case manager.