### PR TITLE
feat(og-images): Migrate OpenGraph image generation back to Edge Runtime

### DIFF
--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -40,3 +40,16 @@ export const getMemberPageBySlug = (slug: string, preview: boolean) =>
   unstable_cache(throttledGetMemberPageBySlug, MEMBER_TAGS.member(slug), {
     tags: MEMBER_TAGS.member(slug),
   })(slug, preview);
+
+/**
+ * Unthrottled version for use in Edge Runtime (e.g., OG images)
+ * where throttling doesn't work across isolated invocations.
+ */
+export const getMemberPageBySlugUnthrottled = (slug: string, preview: boolean) =>
+  unstable_cache(
+    (slug: string, preview: boolean) => cmsRequest(preview).GetMemberPageBySlug({ slug }),
+    MEMBER_TAGS.member(slug),
+    {
+      tags: MEMBER_TAGS.member(slug),
+    },
+  )(slug, preview);

--- a/src/api/resource.ts
+++ b/src/api/resource.ts
@@ -34,3 +34,16 @@ export const getInternalResourceBySlug = (slug: string, preview: boolean) =>
   unstable_cache(throttledGetInternalResourceBySlug, RESOURCES_TAGS.resource(slug), {
     tags: RESOURCES_TAGS.resource(slug),
   })(slug, preview);
+
+/**
+ * Unthrottled version for use in Edge Runtime (e.g., OG images)
+ * where throttling doesn't work across isolated invocations.
+ */
+export const getInternalResourceBySlugUnthrottled = (slug: string, preview: boolean) =>
+  unstable_cache(
+    (slug: string, preview: boolean) => cmsRequest(preview).GetInternalResourceBySlug({ slug }),
+    RESOURCES_TAGS.resource(slug),
+    {
+      tags: RESOURCES_TAGS.resource(slug),
+    },
+  )(slug, preview);

--- a/src/app/(home)/opengraph-image.tsx
+++ b/src/app/(home)/opengraph-image.tsx
@@ -1,6 +1,7 @@
 import { ogImageDefault } from '~/app/_utils/og-image-default';
 
 // Route segment config
+export const runtime = 'edge';
 export const alt = 'ADRsource';
 
 export const size = {

--- a/src/app/(with-color-blur)/about/opengraph-image.tsx
+++ b/src/app/(with-color-blur)/about/opengraph-image.tsx
@@ -1,6 +1,7 @@
 import { ogImageDefault } from '~/app/_utils/og-image-default';
 
 // Route segment config
+export const runtime = 'edge';
 export const alt = 'ADRsource';
 
 export const size = {

--- a/src/app/(with-color-blur)/resources/[slug]/opengraph-image.tsx
+++ b/src/app/(with-color-blur)/resources/[slug]/opengraph-image.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable @next/next/no-img-element */
 import { draftMode } from 'next/headers';
-import { getInternalResourceBySlug } from '~/api/resource';
+import { getInternalResourceBySlugUnthrottled } from '~/api/resource';
 import { makeCmsAssetUrl } from '~/app/_utils/make-cms-asset-url';
 import { ogImageDefault } from '~/app/_utils/og-image-default';
 import { ogImageTemplate } from '~/app/_utils/og-image-template';
 
 // Route segment config
+export const runtime = 'edge';
 export const alt = 'Resource';
 
 export const size = {
@@ -17,7 +18,7 @@ export const contentType = 'image/png';
 export default async function Image({ params }: { params: { slug: string } }) {
   const preview = (await draftMode()).isEnabled;
   const { slug } = params;
-  const data = await getInternalResourceBySlug(slug, preview);
+  const data = await getInternalResourceBySlugUnthrottled(slug, preview);
   const { internalResource } = data;
 
   if (!internalResource) {

--- a/src/app/(with-color-blur)/resources/opengraph-image.tsx
+++ b/src/app/(with-color-blur)/resources/opengraph-image.tsx
@@ -1,6 +1,7 @@
 import { ogImageDefault } from '~/app/_utils/og-image-default';
 
 // Route segment config
+export const runtime = 'edge';
 export const alt = 'ADRsource';
 
 export const size = {

--- a/src/app/(with-color-blur)/schedule/opengraph-image.tsx
+++ b/src/app/(with-color-blur)/schedule/opengraph-image.tsx
@@ -1,6 +1,7 @@
 import { ogImageDefault } from '~/app/_utils/og-image-default';
 
 // Route segment config
+export const runtime = 'edge';
 export const alt = 'ADRsource';
 
 export const size = {

--- a/src/app/(with-color-blur)/team/[member]/opengraph-image.tsx
+++ b/src/app/(with-color-blur)/team/[member]/opengraph-image.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable @next/next/no-img-element */
 import { draftMode } from 'next/headers';
-import { getMemberPageBySlug } from '~/api/member';
+import { getMemberPageBySlugUnthrottled } from '~/api/member';
 import { makeCmsAssetUrl } from '~/app/_utils/make-cms-asset-url';
 import { ogImageDefault } from '~/app/_utils/og-image-default';
 import { ogImageTemplate } from '~/app/_utils/og-image-template';
 
 // Route segment config
+export const runtime = 'edge';
 export const alt = 'Resource';
 
 export const size = {
@@ -17,7 +18,7 @@ export const contentType = 'image/png';
 export default async function Image({ params }: { params: { member: string } }) {
   const preview = (await draftMode()).isEnabled;
   const { member } = params;
-  const data = await getMemberPageBySlug(member, preview);
+  const data = await getMemberPageBySlugUnthrottled(member, preview);
   const { memberPage } = data;
 
   if (!memberPage?.member) {

--- a/src/app/(with-color-blur)/team/opengraph-image.tsx
+++ b/src/app/(with-color-blur)/team/opengraph-image.tsx
@@ -1,6 +1,7 @@
 import { ogImageDefault } from '~/app/_utils/og-image-default';
 
 // Route segment config
+export const runtime = 'edge';
 export const alt = 'ADRsource';
 
 export const size = {

--- a/src/app/_utils/og-image-template.tsx
+++ b/src/app/_utils/og-image-template.tsx
@@ -1,16 +1,14 @@
 /* eslint-disable @next/next/no-img-element */
 import { ImageResponse } from 'next/og';
-import { readFile } from 'node:fs/promises';
-import path from 'node:path';
 import { makeCmsAssetUrl } from '~/app/_utils/make-cms-asset-url';
 
 async function getInterFont() {
-  const fontPath = path.join(process.cwd(), 'src/app/_assets/fonts/Inter-Regular.ttf');
-  return await readFile(fontPath);
+  const res = await fetch(new URL('../_assets/fonts/Inter-Regular.ttf', import.meta.url));
+  return await res.arrayBuffer();
 }
 async function getGloockFont() {
-  const fontPath = path.join(process.cwd(), 'src/app/_assets/fonts/Gloock-Regular.ttf');
-  return await readFile(fontPath);
+  const res = await fetch(new URL('../_assets/fonts/Gloock-Regular.ttf', import.meta.url));
+  return await res.arrayBuffer();
 }
 
 export async function ogImageTemplate({


### PR DESCRIPTION
- Add Edge Runtime support to all opengraph-image routes
- Create unthrottled API variants for member and resource fetching to support Edge Runtime's isolated invocations
- Replace Node.js fs operations with fetch-based font loading using import.meta.url
- Update resource and member OG image routes to use unthrottled API methods